### PR TITLE
Sample.load_sample: add in _name assignment

### DIFF
--- a/cutlass/Sample.py
+++ b/cutlass/Sample.py
@@ -444,6 +444,7 @@ class Sample(Base):
         sample._set_id(sample_data['id'])
         # ver, not version for the key
         sample._version = sample_data['ver']
+        sample._name = sample_data['meta']['name']
         sample._tags = sample_data['meta']['tags']
         sample._mixs = sample_data['meta']['mixs']
         sample._fma_body_site = sample_data['meta']['fma_body_site']


### PR DESCRIPTION
This mod successfully adds in the `search` & `load_sample` assignment of the `name` attribute.
